### PR TITLE
discover: accept any clone form (SSH, HTTPS, git://) for configured org

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,6 +224,70 @@ jobs:
           fi
           echo "PASS: end-to-end mock sync mirrored 2 matching commits with rewritten author"
 
+      - name: Discovery accepts SSH, HTTPS, git:// clone forms for configured org
+        run: |
+          # Regression test: a repo cloned via HTTPS from the same org must be
+          # discovered and normalized to REMOTE_PREFIX, not silently skipped.
+          tmp="$(mktemp -d)"
+          work="$tmp/work" mirror="$tmp/mirror" cache="$tmp/cache" cfg="$tmp/config"
+          mkdir -p "$work" "$mirror" "$cache"
+
+          # Fake repos with different origin forms
+          init_repo() {
+            local dir="$1" url="$2"
+            mkdir -p "$dir" && git -C "$dir" init -q
+            [ -n "$url" ] && git -C "$dir" remote add origin "$url"
+            GIT_AUTHOR_EMAIL=test@test.com GIT_COMMITTER_EMAIL=test@test.com \
+              git -C "$dir" commit --allow-empty -m init -q
+          }
+          init_repo "$work/repo-ssh"       'git@github-work:TestOrg/repo-ssh.git'
+          init_repo "$work/repo-https"     'https://github.com/TestOrg/repo-https.git'
+          init_repo "$work/repo-other"     'git@github.com:OtherOrg/repo-other.git'
+          init_repo "$work/repo-similar"   'https://github.com/TestOrg-Labs/repo-similar.git'
+          init_repo "$work/repo-no-remote" ''
+
+          # Seed mirror repo
+          git -C "$mirror" init -q
+          GIT_AUTHOR_EMAIL=test@test.com GIT_COMMITTER_EMAIL=test@test.com \
+            git -C "$mirror" commit --allow-empty -m init -q
+
+          # Test config (script sources this as the final override)
+          cat > "$cfg" <<EOF
+          WORK_DIR=$work
+          MIRROR_DIR=$mirror
+          CACHE_DIR=$cache
+          REMOTE_PREFIX="git@github-work:TestOrg/"
+          EMAILS="test@test.com"
+          MIRROR_EMAIL="test@test.com"
+          GITHUB_USERNAME="testuser"
+          ACTIVITY_TYPES="commits"
+          SINCE="2024-01-01 00:00:00"
+          EOF
+
+          # Run sync. Fetches will fail (remotes are fake) — we only assert on
+          # the discovery log lines, which run before any network call.
+          out="$(CONTRIB_MIRROR_CONFIG="$cfg" FORCE=1 bash sync.sh 2>&1 || true)"
+          echo "--- sync output ---"
+          echo "$out"
+          echo "--- end output ---"
+
+          assert() {
+            if [ "$1" = "pass" ]; then echo "PASS: $2"
+            else echo "FAIL: $2"; exit 1; fi
+          }
+
+          # Both valid forms must reach the caching step
+          echo "$out" | grep -q 'repo-ssh.git'      && assert pass 'SSH repo discovered'      || assert fail 'SSH repo discovered'
+          echo "$out" | grep -q 'repo-https.git'    && assert pass 'HTTPS repo discovered'    || assert fail 'HTTPS repo discovered'
+          echo "$out" | grep -q 'normalizing.*repo-https' && assert pass 'HTTPS form logged a normalization WARN' || assert fail 'HTTPS form logged a normalization WARN'
+
+          # Non-matching org and missing remote must be skipped
+          echo "$out" | grep -q 'repo-other'        && assert fail 'unrelated org was skipped'    || assert pass 'unrelated org was skipped'
+          echo "$out" | grep -q 'repo-no-remote'    && assert fail 'no-remote repo was skipped'   || assert pass 'no-remote repo was skipped'
+
+          # Substring-collision safety: TestOrg-Labs must not match TestOrg
+          echo "$out" | grep -q 'repo-similar'      && assert fail 'substring-org rejected'       || assert pass 'substring-org rejected'
+
   # Windows smoke tests (Git Bash)
   test-windows:
     runs-on: windows-latest

--- a/sync.sh
+++ b/sync.sh
@@ -484,11 +484,39 @@ find "$WORK_DIR" -maxdepth 2 -name .git -print 2>/dev/null | while read -r gitpa
     continue
   fi
 
-  # Only process repos matching the prefix
+  # Only process repos matching the org. Accept any clone form (SSH/HTTPS/git://)
+  # and normalize to REMOTE_PREFIX so downstream cache/filter logic stays consistent.
+  prefix_trimmed="${REMOTE_PREFIX%/}"
+  if [[ "$prefix_trimmed" == *"://"* ]]; then
+    org_from_prefix="${prefix_trimmed##*/}"   # https://host/Org -> Org
+  else
+    org_from_prefix="${prefix_trimmed##*:}"   # git@host:Org -> Org
+  fi
+  if [[ -z "$org_from_prefix" ]]; then
+    case "$url" in
+      "$REMOTE_PREFIX"*) ;;
+      *) continue ;;
+    esac
+    remote_repo="$(basename "$url")"
+    printf "%s %s\n" "$remote_repo" "$url" >> "$tmp_pairs"
+    continue
+  fi
+  normalized=""
   case "$url" in
-    "$REMOTE_PREFIX"*) ;;
-    *) continue ;;
+    "$REMOTE_PREFIX"*)
+      normalized="$url"
+      ;;
+    *"/$org_from_prefix/"*|*":$org_from_prefix/"*)
+      repo_path="${url##*$org_from_prefix/}"
+      repo_path="${repo_path%.git}"
+      if [[ -n "$repo_path" ]]; then
+        normalized="${REMOTE_PREFIX}${repo_path}.git"
+        [[ "$url" != "$normalized" ]] && log "  WARN: $repodir uses $url; normalizing to $normalized"
+      fi
+      ;;
   esac
+  [[ -z "$normalized" ]] && continue
+  url="$normalized"
 
   remote_repo="$(basename "$url")"
   printf "%s %s\n" "$remote_repo" "$url" >> "$tmp_pairs"


### PR DESCRIPTION
## Summary
- sync.sh's discovery loop matched origin URLs only against the exact `REMOTE_PREFIX` string, so a repo cloned via HTTPS from the same org was silently skipped and never mirrored.
- fix derives the org from `REMOTE_PREFIX` (works for both scp-style `git@host:Org/` and URL-style `https://host/Org/`), matches any clone form containing `/Org/` or `:Org/`, and normalizes matches back to `REMOTE_PREFIX` so downstream logic stays the same.
- logs a WARN on normalize so users notice a misconfigured local clone.
- falls back to strict-prefix match if org derivation produces an empty string.

## Test plan
- [x] local: all 6 assertions pass against the fake-repo harness
- [ ] CI: test step runs on macos-latest and all 6 assertions PASS
- [ ] manual: run `greens sync` against a real work dir that has at least one HTTPS-origin repo, confirm it now discovers

## What the CI test covers
- SSH-form repo discovered
- HTTPS-form repo discovered + normalization WARN emitted
- unrelated org skipped
- no-remote repo skipped
- substring collision (`TestOrg-Labs` vs `TestOrg`) rejected