### PR TITLE
sync: bound each fetch with keepalive + hard timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -288,6 +288,122 @@ jobs:
           # Substring-collision safety: TestOrg-Labs must not match TestOrg
           echo "$out" | grep -q 'repo-similar'      && assert fail 'substring-org rejected'       || assert pass 'substring-org rejected'
 
+      - name: Fetch timeout kills a stuck SSH transport
+        run: |
+          # Regression test: when ssh hangs mid-transfer (no data, no close),
+          # sync.sh must kill the fetch within GREENS_FETCH_TIMEOUT + grace
+          # instead of wedging the whole sync for hours.
+          tmp="$(mktemp -d)"
+          work="$tmp/work" mirror="$tmp/mirror" cache="$tmp/cache" cfg="$tmp/config"
+          mkdir -p "$work" "$mirror" "$cache"
+
+          # Fake SSH wrapper that never returns — simulates the midnight stall
+          # we actually observed in production (ssh alive, no bytes flowing).
+          cat > "$tmp/slow-ssh" <<'SSHEOF'
+          #!/bin/bash
+          sleep 600
+          SSHEOF
+          chmod +x "$tmp/slow-ssh"
+
+          mkdir -p "$work/slow-repo"
+          git -C "$work/slow-repo" init -q
+          git -C "$work/slow-repo" remote add origin git@github.com:TestOrg/slow-repo.git
+          GIT_AUTHOR_EMAIL=test@test.com GIT_COMMITTER_EMAIL=test@test.com \
+            git -C "$work/slow-repo" commit --allow-empty -m init -q
+
+          git -C "$mirror" init -q
+          GIT_AUTHOR_EMAIL=test@test.com GIT_COMMITTER_EMAIL=test@test.com \
+            git -C "$mirror" commit --allow-empty -m init -q
+
+          cat > "$cfg" <<EOF
+          WORK_DIR=$work
+          MIRROR_DIR=$mirror
+          CACHE_DIR=$cache
+          REMOTE_PREFIX="git@github.com:TestOrg/"
+          EMAILS="test@test.com"
+          MIRROR_EMAIL="test@test.com"
+          GITHUB_USERNAME="testuser"
+          ACTIVITY_TYPES="commits"
+          SINCE="2024-01-01 00:00:00"
+          EOF
+
+          # Full stdout to a file; no head/tee pipeline that can short-circuit
+          # the child via SIGPIPE and make the timer reading unreliable.
+          start="$(date +%s)"
+          CONTRIB_MIRROR_CONFIG="$cfg" FORCE=1 GREENS_FETCH_TIMEOUT=5 \
+            GIT_SSH_COMMAND="$tmp/slow-ssh" \
+            bash sync.sh >"$tmp/out.log" 2>&1 || true
+          elapsed="$(( $(date +%s) - start ))"
+
+          echo "--- sync output (first 20 lines) ---"
+          sed -n '1,20p' "$tmp/out.log" || true
+          echo "--- end output ---"
+          echo "elapsed=${elapsed}s"
+
+          # Budget: timeout (5) + grace (10) + overhead (~15) = 30s realistic.
+          # If it takes 60+ seconds the wrapper didn't actually kill ssh.
+          if [ "$elapsed" -lt 60 ]; then
+            echo "PASS: fetch timeout kicked in (${elapsed}s)"
+          else
+            echo "FAIL: sync took ${elapsed}s, timeout wrapper didn't kill ssh"
+            exit 1
+          fi
+
+          # Sync should log the warn for the failed repo before aborting.
+          if grep -q 'WARN.*slow-repo' "$tmp/out.log"; then
+            echo "PASS: failed fetch logged with WARN"
+          else
+            echo "FAIL: expected WARN for slow-repo in output"
+            cat "$tmp/out.log"
+            exit 1
+          fi
+
+      - name: Perl timeout fallback kills process group
+        run: |
+          # Exercise the perl fallback directly, without relying on a fragile
+          # PATH shim for sync.sh. This validates the bit of logic that kicks
+          # in when gtimeout/timeout are missing.
+          run_with_timeout() {
+            local seconds="$1"; shift
+            perl -e 'setpgrp 0,0; exec @ARGV or die "exec failed: $!"' "$@" &
+            local pid=$!
+            (
+              sleep "$seconds"
+              kill -TERM -"$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null
+              sleep 10
+              kill -KILL -"$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null
+            ) &
+            local watcher=$!
+            wait "$pid" 2>/dev/null
+            local rc=$?
+            kill "$watcher" 2>/dev/null
+            wait "$watcher" 2>/dev/null
+            return "$rc"
+          }
+
+          # Unique sentinel so the orphan check can't collide with unrelated
+          # `sleep` processes on the runner.
+          marker="greens-timeout-test-$RANDOM-$$"
+          start="$(date +%s)"
+          run_with_timeout 2 bash -c "exec -a $marker sleep 600" || true
+          elapsed="$(( $(date +%s) - start ))"
+          echo "elapsed=${elapsed}s"
+          if [ "$elapsed" -lt 30 ]; then
+            echo "PASS: perl fallback killed child (${elapsed}s)"
+          else
+            echo "FAIL: perl fallback didn't kill child within budget (${elapsed}s)"
+            exit 1
+          fi
+
+          # Confirm the sentinel-named child didn't leak out of the wrapper.
+          if pgrep -f "$marker" >/dev/null 2>&1; then
+            echo "FAIL: orphan child still running after wrapper returned"
+            pkill -9 -f "$marker" 2>/dev/null || true
+            exit 1
+          else
+            echo "PASS: no orphan child after wrapper returned"
+          fi
+
   # Windows smoke tests (Git Bash)
   test-windows:
     runs-on: windows-latest

--- a/sync.sh
+++ b/sync.sh
@@ -533,6 +533,50 @@ LC_ALL=C sort -u "$tmp_pairs" > "$tmp_sorted"
 # Fetch into bare caches (safe for local WIP)
 # ─────────────────────────────────────────────────────────────────────────────
 
+# Never block on auth/host-key prompts and drop stalled SSH connections fast.
+# Without ServerAliveInterval a midnight launchd/cron run can hang for hours
+# when WiFi drops mid-transfer — ssh stays alive with no progress.
+# Honor pre-set values so users can tune via their environment.
+: "${GIT_TERMINAL_PROMPT:=0}"
+: "${GIT_SSH_COMMAND:=ssh -o BatchMode=yes -o ServerAliveInterval=10 -o ServerAliveCountMax=3 -o ConnectTimeout=30}"
+export GIT_TERMINAL_PROMPT GIT_SSH_COMMAND
+
+# Per-fetch hard timeout so one stuck repo can't wedge the whole sync.
+# Prefer GNU coreutils, then macOS-native timeout, else a Bash-native fallback
+# that kills the whole process group.
+GREENS_FETCH_TIMEOUT="${GREENS_FETCH_TIMEOUT:-120}"
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(gtimeout --kill-after=10 "$GREENS_FETCH_TIMEOUT")
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(timeout --kill-after=10 "$GREENS_FETCH_TIMEOUT")
+elif command -v perl >/dev/null 2>&1; then
+  # perl setpgrp makes the exec'd command a process group leader, so
+  # kill -TERM -$pid terminates git AND its ssh child. If setpgrp is a
+  # no-op on this platform, the negative-pid kill falls back to the
+  # positive-pid form so at least git itself gets terminated.
+  run_with_timeout() {
+    local seconds="$1"; shift
+    perl -e 'setpgrp 0,0; exec @ARGV or die "exec failed: $!"' "$@" &
+    local pid=$!
+    (
+      sleep "$seconds"
+      kill -TERM -"$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null
+      sleep 10
+      kill -KILL -"$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null
+    ) &
+    local watcher=$!
+    wait "$pid" 2>/dev/null
+    local rc=$?
+    kill "$watcher" 2>/dev/null
+    wait "$watcher" 2>/dev/null
+    return "$rc"
+  }
+  TIMEOUT_CMD=(run_with_timeout "$GREENS_FETCH_TIMEOUT")
+else
+  log "WARN: no timeout or perl available; fetches won't be bounded."
+  TIMEOUT_CMD=()
+fi
+
 repo_total="$(wc -l < "$tmp_sorted" | tr -d " ")"
 log ""
 log "Step 2/5: Caching $repo_total repos (read-only copies — your code stays untouched)"
@@ -545,7 +589,7 @@ while read -r remote_repo url; do
 
   if [[ ! -d "$bare" ]]; then
     log "Cloning $remote_repo"
-    if ! err="$(git clone --bare --filter=blob:none --no-tags "$url" "$bare" 2>&1)"; then
+    if ! err="$("${TIMEOUT_CMD[@]}" git clone --bare --filter=blob:none --no-tags "$url" "$bare" 2>&1)"; then
       log "WARN: clone failed for $remote_repo: $(echo "$err" | tail -n 3 | tr '\n' ' ')"
       failures=$((failures + 1))
       rm -rf "$bare" >/dev/null 2>&1 || true
@@ -560,7 +604,7 @@ while read -r remote_repo url; do
   fi
 
   log "Fetching $remote_repo"
-  if ! err="$(git --git-dir="$bare" fetch --prune --no-tags --filter=blob:none origin "+refs/heads/*:refs/heads/*" 2>&1)"; then
+  if ! err="$("${TIMEOUT_CMD[@]}" git --git-dir="$bare" fetch --prune --no-tags --filter=blob:none origin "+refs/heads/*:refs/heads/*" 2>&1)"; then
     log "WARN: fetch failed for $remote_repo: $(echo "$err" | tail -n 3 | tr '\n' ' ')"
     failures=$((failures + 1))
     continue


### PR DESCRIPTION
## Summary
A launchd/cron sync wedged for 1.5 hours on a single repo's SSH fetch — ssh connection stayed alive but transferred no bytes. Every subsequent midnight run would have done the same until someone caught it.

Two-layer fix:

**1. Non-interactive SSH with keepalive + connect timeout**
- `GIT_TERMINAL_PROMPT=0` prevents blocking on prompts
- `GIT_SSH_COMMAND` override: `BatchMode=yes`, `ServerAliveInterval=10`, `ServerAliveCountMax=3`, `ConnectTimeout=30`
- Stalled TCP drops in ~30s instead of waiting forever
- Env-overridable so users on flaky links can tune or disable

**2. Per-fetch hard timeout**
- Default 120s, override via `GREENS_FETCH_TIMEOUT`
- Prefers `gtimeout` (GNU coreutils), then macOS `timeout`, else a perl `setpgrp` wrapper that kills the whole process group so ssh children don't survive the parent
- Negative-pid kill with positive-pid fallback in case `setpgrp` is a no-op on some platform

## Test plan
- [x] local: gtimeout path — full real sync completes in ~70s (no false timeouts on healthy fetches)
- [x] local: perl fallback — `run_with_timeout 2 bash -c 'sleep 600'` returns in 2s, no orphan child
- [x] local: hung-ssh integration — sync.sh with sleep-ssh aborts in 5s (timeout=5), WARN logged
- [ ] CI: both new test steps pass on macos-latest

## CI coverage added
- "Fetch timeout kills a stuck SSH transport": full-sync integration test with a fake `sleep 600` ssh wrapper. Asserts sync aborts within 60s and logs a WARN for the stuck repo. Runs with `GREENS_FETCH_TIMEOUT=5` for a fast test.
- "Perl timeout fallback kills process group": self-contained test of the perl wrapper against `bash -c "exec -a $marker sleep 600"`. Asserts elapsed < 30s and no orphan child matching the unique sentinel marker remains.